### PR TITLE
Added in some Backward Compatibility so old INI's with ^ separators s…

### DIFF
--- a/MQ2Medley.sln
+++ b/MQ2Medley.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34330.188
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MQ2Medley", "MQ2Medley.vcxproj", "{ABA82111-9799-4FF0-8261-B887394F8100}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Debug|x64.ActiveCfg = Debug|x64
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Debug|x64.Build.0 = Debug|x64
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Debug|x86.ActiveCfg = Debug|Win32
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Debug|x86.Build.0 = Debug|Win32
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Release|x64.ActiveCfg = Release|x64
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Release|x64.Build.0 = Release|x64
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Release|x86.ActiveCfg = Release|Win32
+		{ABA82111-9799-4FF0-8261-B887394F8100}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {89E1B8B6-FD11-4B60-B809-7F1791DBAB8C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
…till work as intended.

Changed INI layout for Swapping and made it consistent with other INI's for MQ using | separators and cond1 etc. variables for conditions. Now checks for cond# statements and looks those up for conditions, this allowed the use of | separators without an or statement breaking it. Item swapping can now be done one of 2 ways.
1: With the in game bandolier command, this requires you to save your hotkeys in game and define the hotkey name in the config. toggle Bandolier use (on/1) or (off/0) with /medley bandolier will toggle between bandolier mode and exchange mode. bandolier entries are defined per song. so song1 would pair with bandolier1 in your config. if no bandolier is set we do not swap. 2: With the MQ2Exchange plugin loaded.
you define swap sets like conditions swap1=itemname|slotname|itemname|slotname you can also define sets with itemnumber|slotnumber this accepts multiple items and slots.
Added variables for MainHand and OffHand that if set will be used for any instance where you do not define a swapSet in the song string. Item swaps check current known items against what to swap and ignores anything that we should already have equipped. Song strings using the new layout look like this.
song1=SongName|Duration|SwapSet|Condition
swap set and condition are optional and will default to noswap and 1 respectively. all of the below will be valid entries.
song1=SongName|Duration|SwapSet|Condition
song1=SongName|Duration|SwapSet #Sets the default condition to 1 song1=SongName|Duration|Condition #Sets default SwapSet to MainHand OffHand items if defined, else just plays the song song1=SongName|Duration #Same as above but also defaults the condition to 1